### PR TITLE
Update angular-bootstrap-select.js

### DIFF
--- a/src/angular-bootstrap-select.js
+++ b/src/angular-bootstrap-select.js
@@ -3,6 +3,11 @@ angular.module('angular-bootstrap-select.extra', [])
     return {
       restrict: 'A',
       link: function (scope, element, attrs) {
+        //prevent directive from attaching itself to everything that defines a toggle attribute
+        if (!element.hasClass('selectPicker')) {
+          return;
+        }
+        
         var target = element.parent();
 
         element.bind('click', function () {


### PR DESCRIPTION
Prevent the toggle directive from attaching itself to everything that defines a toggle attribute. This fixes an issue where bootstrap select would interfere with the built-in bootstrap dropdowns etc.
