### PR TITLE
selectpicker now stays in sync with original select's ngModel

### DIFF
--- a/src/angular-bootstrap-select.js
+++ b/src/angular-bootstrap-select.js
@@ -19,13 +19,21 @@ angular.module('angular-bootstrap-select.extra', [])
 angular.module('angular-bootstrap-select', [])
   .directive('selectpicker', function () {
     return {
-      restrict: 'CA',
+      restrict: 'A',
       require: '?ngModel',
       compile: function (tElement, tAttrs, transclude) {
         tElement.selectpicker();
         return function (scope, element, attrs, ngModel) {
+          if(angular.isUndefined(ngModel)){
+            return;
+          }
+          scope.$watch(attrs.ngModel, function() {
+            $timeout(function() {
+              element.selectpicker('val', element.val());
+            });
+          });
           ngModel.$render = function() {
-            element.val(ngModel.$viewValue || '').selectpicker('render');
+            element.selectpicker('val', ngModel.$viewValue || '');
           };
           ngModel.$viewValue = element.val();
         };


### PR DESCRIPTION
- Removed the `restrict: 'C'` because it's uncommon in angular and causes the directive to attach to additional elements with `.selectpicker` created by the selectpicker plugin itself.
- stays in sync with the original ngModel due to the `$watch` and `$timeout`
  - `$timeout` is there because without, it would sometimes conflict with a currently running `$digest` cycle, and wrapping the function in a `$timeout` is the accepted method for running a function on the next open `$digest`.
- Also incorporates the `if ngModel is undefined conditional` that others have implemented and asked for.
