### PR TITLE
Possible to remove ngModel.$render function with Angular v1.3.0?

### DIFF
--- a/src/angular-bootstrap-select.js
+++ b/src/angular-bootstrap-select.js
@@ -22,6 +22,7 @@ angular.module('angular-bootstrap-select.extra', [])
     };
   });
 
+// Updated to work with Angular v1.3.0 (tested with 1.3.0-beta.17)
 angular.module('angular-bootstrap-select', [])
 .directive('selectpicker', ['$timeout', '$parse', function ($timeout, $parse) {
     return {


### PR DESCRIPTION
When using Angular v1.3.0-beta.17 and attempting to place selectpickers inside a Kendo UI TabStrip, I received errors which basically eluded to the fact that event data wasn't present. While I couldn't track down the precise cause of the error, I eventually solved the problem by reworking the compile section (I introduced a 'postLink' function in place of the plain return [may be unnecessary]). I discovered that, at least in my scenario, removing the entire 'ngModel.$render' function not only stopped the errors but still allowed the pickers to work perfectly, inside and outside of the Kendo TabStrip. Obviously, this removal is subject to review, since @joaoneto authored it to be there. Perhaps there are changes with Angular 1.3.0 that allow a simplification of this directive? Even if my code structure isn't acceptable, I request the review of the removal of the ngModel.$render function.
