### PR TITLE
fix version syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-bootstrap-select",
-  "version": "0.1.0rc2",
+  "version": "0.1.0-rc2",
   "main": "./build/angular-bootstrap-select.js",
   "description": "Directive to wrap bootstrap-select",
   "author": "https://github.com/joaoneto/angular-bootstrap-select/graphs/contributors",


### PR DESCRIPTION
http://semver.org/spec/v2.0.0.html rule 9 specifies:

"A pre-release version MAY be denoted by appending a **hyphen** and a series of dot separated identifiers"

`bower install` is broken otherwise.