### PR TITLE
Fix $http AJAX request timing issue

### DIFF
--- a/src/angular-bootstrap-select.js
+++ b/src/angular-bootstrap-select.js
@@ -203,6 +203,10 @@ function selectpickerDirective($parse, $timeout) {
       if (attrs.ngModel) {
         scope.$watch(attrs.ngModel, refresh, true);
       }
+      
+      if (attrs.ngOptions && / in /.test(attrs.ngOptions)) {
+        scope.$watch(attrs.ngOptions.split(' in ')[1], refresh, true);
+      }
 
       if (attrs.ngDisabled) {
         scope.$watch(attrs.ngDisabled, refresh, true);


### PR DESCRIPTION
Making an $http (AJAX) request is giving timing issues, the bootstrap-select does not get refresh properly (or too early) and end up like an empty list because of timing issues. 
See the Issue #33 : https://github.com/joaoneto/angular-bootstrap-select/issues/33
Also the StackOverflow question and answer : http://stackoverflow.com/questions/28336106/angular-bootstrap-select-timing-issue-to-refresh/28376105#28376105